### PR TITLE
Refactor/domain responsibility

### DIFF
--- a/advertisement-service/src/main/java/com/bidcast/advertisement_service/campaign/Campaign.java
+++ b/advertisement-service/src/main/java/com/bidcast/advertisement_service/campaign/Campaign.java
@@ -2,6 +2,7 @@ package com.bidcast.advertisement_service.campaign;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.AccessLevel; // Import faltante
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -14,14 +15,15 @@ import java.util.UUID;
 @Entity
 @Table(name = "campaigns")
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@Setter(AccessLevel.PROTECTED) 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor // Visible para el Builder
 @Builder
 public class Campaign {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Setter(AccessLevel.NONE)
     private UUID id;
 
     @Column(nullable = false, length = 100)
@@ -29,6 +31,7 @@ public class Campaign {
 
     
     @Column(nullable = false)
+    @Setter(AccessLevel.NONE)
     private UUID advertiserId;
 
     
@@ -37,7 +40,8 @@ public class Campaign {
 
     @Builder.Default
     @Column(nullable = false, precision = 12, scale = 4)
-    private BigDecimal spent = BigDecimal.ZERO; // todavia no lo uso
+    @Setter(AccessLevel.NONE)
+    private BigDecimal spent = BigDecimal.ZERO;
 
     @Column(nullable = false, precision = 12, scale = 4)
     private BigDecimal bidCpm;
@@ -48,10 +52,12 @@ public class Campaign {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
+    @Setter(AccessLevel.NONE)
     private CampaignStatusType status;
 
     @Builder.Default
     @OneToMany(mappedBy = "campaign", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Setter(AccessLevel.NONE)
     private List<Creative> creatives = new ArrayList<>();
 
     @CreationTimestamp
@@ -60,4 +66,54 @@ public class Campaign {
 
     @UpdateTimestamp
     private Instant updatedAt;
+
+    /**
+     * Activa una campaña que está en borrador o programada.
+     */
+    public void activate() {
+        if (creatives.isEmpty()) {
+            throw new IllegalStateException("Cannot activate a campaign without creatives");
+        }
+        if (status == CampaignStatusType.FINISHED) {
+            throw new IllegalStateException("Cannot reactivate a finished campaign");
+        }
+        status = CampaignStatusType.ACTIVE;
+    }
+
+    /**
+     * Pausa una campaña activa.
+     */
+    public void pause() {
+        if (this.status != CampaignStatusType.ACTIVE) {
+            throw new IllegalStateException("Can only pause active campaigns");
+        }
+        this.status = CampaignStatusType.PAUSED;
+    }
+
+    /**
+     * Reanuda una campaña pausada.
+     */
+    public void resume() {
+        if (this.status != CampaignStatusType.PAUSED) {
+            throw new IllegalStateException("Can only resume paused campaigns");
+        }
+        this.status = CampaignStatusType.ACTIVE;
+    }
+
+    /**
+     * Finaliza la campaña.
+     */
+    public void finish() {
+        this.status = CampaignStatusType.FINISHED;
+    }
+
+    /**
+     * Registra un gasto en la campaña y comprueba si ha finalizado el presupuesto.
+     */
+    public void registerSpend(BigDecimal amount) {
+        this.spent = this.spent.add(amount);
+        if (this.spent.compareTo(this.budget) >= 0) {
+            this.finish();
+        }
+    }
 }

--- a/auction-service/src/main/java/com/bidcast/auction_service/bid/BidPersistenceService.java
+++ b/auction-service/src/main/java/com/bidcast/auction_service/bid/BidPersistenceService.java
@@ -34,14 +34,51 @@ public class BidPersistenceService {
         return sessionBidRepository.save(bid);
     }
 
-    // metodo para crear una transaccion independiente en el cual se updetea el estado de un sessionBid
+    // Activa la puja
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public SessionBid updateStatus(UUID bidId, BidStatus status) {
+    public SessionBid activate(UUID bidId) {
         return sessionBidRepository.findById(bidId)
                 .map(bid -> {
-                    bid.setStatus(status);
+                    bid.activate();
                     return sessionBidRepository.save(bid);
                 })
-                .orElseThrow(() -> new RuntimeException("Puja no encontrada para actualizar estado: " + bidId));
+                .orElseThrow(() -> new RuntimeException("Bid not found to activate: " + bidId));
+    }
+
+    // Marca la puja como fallida
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void fail(UUID bidId) {
+        sessionBidRepository.findById(bidId).ifPresent(bid -> {
+            bid.fail();
+            sessionBidRepository.save(bid);
+        });
+    }
+
+    // Marca un fallo crítico
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markCriticalFailure(UUID bidId) {
+        sessionBidRepository.findById(bidId).ifPresent(bid -> {
+            bid.markCriticalFailure();
+            sessionBidRepository.save(bid);
+        });
+    }
+
+    // Marca la puja como agotada (sin presupuesto)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void exhaust(UUID bidId) {
+        sessionBidRepository.findById(bidId).ifPresent(bid -> {
+            // Necesitamos añadir este método en la entidad SessionBid
+            bid.exhaust();
+            sessionBidRepository.save(bid);
+        });
+    }
+
+    // Cierra la puja al finalizar la sesión
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void close(UUID bidId) {
+        sessionBidRepository.findById(bidId).ifPresent(bid -> {
+            bid.close();
+            sessionBidRepository.save(bid);
+        });
     }
 }

--- a/auction-service/src/main/java/com/bidcast/auction_service/bid/BidRegistrationService.java
+++ b/auction-service/src/main/java/com/bidcast/auction_service/bid/BidRegistrationService.java
@@ -24,7 +24,7 @@ public class BidRegistrationService {
     private final SessionService sessionService;
 
     // metodo para registrar un bid
-    // mini saga (compensitory), ya que estamos tocando db del wallet service, hay que tener en cuenta 
+    // mini saga (compensatory), ya que estamos tocando db del wallet service, hay que tener en cuenta 
     // y lograr una transaccion distribuida
     public SessionBid registerBid(BidRegistrationRequest request) {
         log.info("Registering bid for advertiser {} in session {}", request.advertiserId(), request.sessionId());
@@ -48,13 +48,13 @@ public class BidRegistrationService {
             ));
         } catch (Exception e) {
             log.error("Failed to freeze funds for bid {}. Cancelling registration.", bid.getId());
-            persistenceService.updateStatus(bid.getId(), BidStatus.FAILED);
+            persistenceService.fail(bid.getId());
             throw new WalletCommunicationException("Wallet service communication failure");
         }
 
         // 3. Activación e Inyección en Redis (Hot Data)
         try {
-            SessionBid activeBid = persistenceService.updateStatus(bid.getId(), BidStatus.ACTIVE);
+            SessionBid activeBid = persistenceService.activate(bid.getId());
             
             // Calculamos el saldo real (que en este punto es el totalBudget) e inyectamos
             long balanceCents = rehydrationService.calculateRealBalanceCents(activeBid);
@@ -78,10 +78,10 @@ public class BidRegistrationService {
                     referenceId,
                     "Rollback due to infrastructure failure"
             ));
-            persistenceService.updateStatus(bid.getId(), BidStatus.FAILED);
+            persistenceService.fail(bid.getId());
         } catch (Exception ex) {
             log.error("CRITICAL ALERT: Failed to unfreeze bid {}. Status: FAILED_CRITICAL", bid.getId());
-            persistenceService.updateStatus(bid.getId(), BidStatus.FAILED_CRITICAL);
+            persistenceService.markCriticalFailure(bid.getId());
         }
     }
 }

--- a/auction-service/src/main/java/com/bidcast/auction_service/bid/SessionBid.java
+++ b/auction-service/src/main/java/com/bidcast/auction_service/bid/SessionBid.java
@@ -5,13 +5,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.*;
+import lombok.AccessLevel;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
-// Entidad de un Bid de session para un Advertiser
 @Entity
 @Table(
     name = "session_bids",
@@ -21,8 +21,8 @@ import java.util.UUID;
     }
 )
 @Getter
-@Setter
-@NoArgsConstructor
+@Setter(AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class SessionBid {
@@ -33,39 +33,86 @@ public class SessionBid {
 
     @Column(nullable = false)
     @NotBlank(message = "Session id is required")
+    @Setter(AccessLevel.NONE)
     private String sessionId;
 
     @Column(nullable = false)
     @NotBlank(message = "Advertiser id is required")
+    @Setter(AccessLevel.NONE)
     private String advertiserId;
 
     @Column(nullable = false)
     @NotBlank(message = "Campaign id is required")
+    @Setter(AccessLevel.NONE)
     private String campaignId;
 
     @Column(nullable = false, precision = 19, scale = 4)
     @NotNull(message = "Total budget is required")
     @Positive(message = "Total budget must be positive")
+    @Setter(AccessLevel.NONE)
     private BigDecimal totalBudget;
 
     @Column(nullable = false, precision = 19, scale = 4)
     @NotNull(message = "Advertiser bid price is required")
     @Positive(message = "Advertiser bid price must be positive")
+    @Setter(AccessLevel.NONE)
     private BigDecimal advertiserBidPrice;
 
     @Column(nullable = false)
     @NotBlank(message = "Media URL is required")
+    @Setter(AccessLevel.NONE)
     private String mediaUrl;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @NotNull(message = "Bid status is required")
+    @Setter(AccessLevel.NONE)
     private BidStatus status;
 
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private Instant createdAt;
 
     @Version
+    @Setter(AccessLevel.NONE)
     private Long version;
+
+    /**
+     * Activa la puja tras la reserva exitosa de fondos.
+     */
+    public void activate() {
+        if (this.status != BidStatus.PENDING_RESERVATION) {
+            throw new IllegalStateException("Can only activate bids in PENDING_RESERVATION status");
+        }
+        this.status = BidStatus.ACTIVE;
+    }
+
+    /**
+     * Marca la puja como fallida durante el proceso de registro.
+     */
+    public void fail() {
+        this.status = BidStatus.FAILED;
+    }
+
+    /**
+     * Marca la puja con un fallo crítico de infraestructura.
+     */
+    public void markCriticalFailure() {
+        this.status = BidStatus.FAILED_CRITICAL;
+    }
+
+    /**
+     * Marca la puja como agotada (sin presupuesto).
+     */
+    public void exhaust() {
+        this.status = BidStatus.EXHAUSTED;
+    }
+
+    /**
+     * Cierra la puja al finalizar la sesión.
+     */
+    public void close() {
+        this.status = BidStatus.CLOSED;
+    }
 }

--- a/auction-service/src/main/java/com/bidcast/auction_service/pop/ProofOfPlayService.java
+++ b/auction-service/src/main/java/com/bidcast/auction_service/pop/ProofOfPlayService.java
@@ -3,7 +3,6 @@ package com.bidcast.auction_service.pop;
 import com.bidcast.auction_service.bid.BidInfrastructureService;
 import com.bidcast.auction_service.bid.BidPersistenceService;
 import com.bidcast.auction_service.bid.BidRehydrationService;
-import com.bidcast.auction_service.bid.BidStatus;
 import com.bidcast.auction_service.bid.RestoredBid;
 import com.bidcast.auction_service.auction.ReceiptTokenService;
 import com.bidcast.auction_service.auction.ValidatedReceipt;
@@ -141,6 +140,6 @@ public class ProofOfPlayService {
     //metodo privado para borrar de redis e marcar un Bid EXHAUSTED
     public void handleExhaustedBid(String sessionId, String bidId) {
         infrastructureService.removeFromActiveIndex(sessionId, bidId);
-        persistenceService.updateStatus(UUID.fromString(bidId), BidStatus.EXHAUSTED);
+        persistenceService.exhaust(UUID.fromString(bidId));
     }
 }

--- a/auction-service/src/main/java/com/bidcast/auction_service/session/DeviceSession.java
+++ b/auction-service/src/main/java/com/bidcast/auction_service/session/DeviceSession.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
+import lombok.AccessLevel;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.Instant;
@@ -19,32 +20,49 @@ import java.time.Instant;
     }
 )
 @Getter
-@Setter
-@NoArgsConstructor
+@Setter(AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class DeviceSession {
 
     @Id
     @NotBlank(message = "Session id must not be blank")
+    @Setter(AccessLevel.NONE)
     private String sessionId;
 
     @Column(nullable = false)
     @NotBlank(message = "Device id is required")
+    @Setter(AccessLevel.NONE)
     private String deviceId;
 
     @Column(nullable = false)
     @NotBlank(message = "Publisher id is required")
+    @Setter(AccessLevel.NONE)
     private String publisherId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @NotNull(message = "Session status is required")
+    @Setter(AccessLevel.NONE)
     private SessionStatus status;
 
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
+    @Setter(AccessLevel.NONE)
     private Instant startedAt;
 
+    @Setter(AccessLevel.NONE)
     private Instant closedAt;
+
+    /**
+     * Cierra la sesión de forma controlada.
+     */
+    public void close() {
+        if (this.status == SessionStatus.CLOSED) {
+            return; // Idempotencia
+        }
+        this.status = SessionStatus.CLOSED;
+        this.closedAt = Instant.now();
+    }
 }

--- a/auction-service/src/main/java/com/bidcast/auction_service/session/SessionService.java
+++ b/auction-service/src/main/java/com/bidcast/auction_service/session/SessionService.java
@@ -37,8 +37,7 @@ public class SessionService {
         log.info("Closing local session tracker {}", sessionId);
         
         sessionRepository.findById(sessionId).ifPresent(foundSession -> {
-            foundSession.setStatus(SessionStatus.CLOSED);
-            foundSession.setClosedAt(Instant.now());
+            foundSession.close();
             sessionRepository.save(foundSession);
         });
     }

--- a/auction-service/src/main/java/com/bidcast/auction_service/settlement/SettlementOrchestrator.java
+++ b/auction-service/src/main/java/com/bidcast/auction_service/settlement/SettlementOrchestrator.java
@@ -55,7 +55,7 @@ public class SettlementOrchestrator {
                     // guardamos el event dentro de la transaccion para desp mandarlo
                     saveSettlementCommandInOutbox(bid, publisherId, spentAmount);
                 }
-                persistenceService.updateStatus(bid.getId(), BidStatus.CLOSED);
+                persistenceService.close(bid.getId());
             } catch (Exception e) {
                 log.error("Critical failure while settling bid {}: {}", bid.getId(), e.getMessage());
                 throw e; // Relanzamos para disparar rollback de la transacción de DB.

--- a/auction-service/src/test/java/com/bidcast/auction_service/bid/BidRegistrationServiceTest.java
+++ b/auction-service/src/test/java/com/bidcast/auction_service/bid/BidRegistrationServiceTest.java
@@ -3,6 +3,7 @@ package com.bidcast.auction_service.bid;
 import com.bidcast.auction_service.client.WalletClient;
 import com.bidcast.auction_service.core.exception.SessionInactiveException;
 import com.bidcast.auction_service.core.exception.WalletCommunicationException;
+import com.bidcast.auction_service.bid.BidRehydrationService;
 import com.bidcast.auction_service.session.SessionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,17 +23,18 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class BidRegistrationServiceTest {
 
+    @Mock private SessionService sessionService;
     @Mock private BidPersistenceService persistenceService;
+    @Mock private WalletClient walletClient;
     @Mock private BidInfrastructureService infrastructureService;
     @Mock private BidRehydrationService rehydrationService;
-    @Mock private WalletClient walletClient;
-    @Mock private SessionService sessionService;
 
     @InjectMocks
     private BidRegistrationService registrationService;
 
     private BidRegistrationRequest request;
     private SessionBid pendingBid;
+    private SessionBid activeBid;
 
     @BeforeEach
     void setUp() {
@@ -47,6 +49,14 @@ class BidRegistrationServiceTest {
                 .totalBudget(new BigDecimal("10.00"))
                 .status(BidStatus.PENDING_RESERVATION)
                 .build();
+        
+        activeBid = SessionBid.builder()
+                .id(pendingBid.getId())
+                .sessionId("session-1")
+                .advertiserId("adv-1")
+                .totalBudget(new BigDecimal("10.00"))
+                .status(BidStatus.ACTIVE)
+                .build();
     }
 
     @Test
@@ -54,15 +64,16 @@ class BidRegistrationServiceTest {
     void registerBid_Success() {
         when(sessionService.isSessionActive("session-1")).thenReturn(true);
         when(persistenceService.saveAsPending(any())).thenReturn(pendingBid);
-        when(persistenceService.updateStatus(any(), eq(BidStatus.ACTIVE))).thenReturn(pendingBid);
+        when(persistenceService.activate(any())).thenReturn(activeBid);
         when(rehydrationService.calculateRealBalanceCents(any(SessionBid.class))).thenReturn(1000L);
 
         SessionBid result = registrationService.registerBid(request);
 
         assertNotNull(result);
+        assertEquals(BidStatus.ACTIVE, result.getStatus());
         verify(walletClient).freeze(any());
         verify(infrastructureService).injectIntoRedis(any(), eq(1000L));
-        verify(persistenceService).updateStatus(any(), eq(BidStatus.ACTIVE));
+        verify(persistenceService, never()).fail(any());
     }
 
     @Test
@@ -83,7 +94,7 @@ class BidRegistrationServiceTest {
 
         assertThrows(WalletCommunicationException.class, () -> registrationService.registerBid(request));
         
-        verify(persistenceService).updateStatus(pendingBid.getId(), BidStatus.FAILED);
+        verify(persistenceService).fail(pendingBid.getId());
         verifyNoInteractions(infrastructureService);
     }
 
@@ -92,7 +103,7 @@ class BidRegistrationServiceTest {
     void registerBid_TriggersCompensationOnRedisFailure() {
         when(sessionService.isSessionActive("session-1")).thenReturn(true);
         when(persistenceService.saveAsPending(any())).thenReturn(pendingBid);
-        when(persistenceService.updateStatus(any(), eq(BidStatus.ACTIVE))).thenReturn(pendingBid);
+        when(persistenceService.activate(any())).thenReturn(activeBid);
         
         // Simular fallo en la inyección a Redis
         doThrow(new RuntimeException("Redis Down")).when(infrastructureService).injectIntoRedis(any(), anyLong());
@@ -102,6 +113,6 @@ class BidRegistrationServiceTest {
         // Verificar que se llamó al unfreeze
         verify(walletClient).unfreeze(any());
         // Verificar que se marcó como FAILED al final
-        verify(persistenceService).updateStatus(pendingBid.getId(), BidStatus.FAILED);
+        verify(persistenceService).fail(pendingBid.getId());
     }
 }

--- a/auction-service/src/test/java/com/bidcast/auction_service/pop/ProofOfPlayServiceTest.java
+++ b/auction-service/src/test/java/com/bidcast/auction_service/pop/ProofOfPlayServiceTest.java
@@ -3,7 +3,6 @@ package com.bidcast.auction_service.pop;
 import com.bidcast.auction_service.bid.BidInfrastructureService;
 import com.bidcast.auction_service.bid.BidPersistenceService;
 import com.bidcast.auction_service.bid.BidRehydrationService;
-import com.bidcast.auction_service.bid.BidStatus;
 import com.bidcast.auction_service.bid.RestoredBid;
 import com.bidcast.auction_service.auction.ReceiptTokenService;
 import com.bidcast.auction_service.auction.ValidatedReceipt;
@@ -173,6 +172,6 @@ class ProofOfPlayServiceTest {
         proofOfPlayService.recordPlay(request);
 
         verify(infrastructureService).removeFromActiveIndex(sessionId, bidId.toString());
-        verify(persistenceService).updateStatus(bidId, BidStatus.EXHAUSTED);
+        verify(persistenceService).exhaust(bidId);
     }
 }

--- a/auction-service/src/test/java/com/bidcast/auction_service/settlement/SettlementOrchestratorTest.java
+++ b/auction-service/src/test/java/com/bidcast/auction_service/settlement/SettlementOrchestratorTest.java
@@ -78,7 +78,7 @@ class SettlementOrchestratorTest {
         SessionSettlementCommand cmd = objectMapper.readValue(captured.getPayload(), SessionSettlementCommand.class);
         
         assertEquals(0, new BigDecimal("6.00").compareTo(cmd.totalSpent()));
-        verify(persistenceService).updateStatus(activeBid.getId(), BidStatus.CLOSED);
+        verify(persistenceService).close(activeBid.getId());
     }
 
     @Test
@@ -91,7 +91,7 @@ class SettlementOrchestratorTest {
         orchestrator.orchestrateSettlement(sessionId, pubId);
 
         verify(outboxRepository, never()).save(any());
-        verify(persistenceService).updateStatus(activeBid.getId(), BidStatus.CLOSED);
+        verify(persistenceService).close(activeBid.getId());
     }
 
     @Test
@@ -114,6 +114,6 @@ class SettlementOrchestratorTest {
 
         assertDoesNotThrow(() -> orchestrator.orchestrateSettlement(sessionId, pubId));
 
-        verify(persistenceService).updateStatus(activeBid.getId(), BidStatus.CLOSED);
+        verify(persistenceService).close(activeBid.getId());
     }
 }

--- a/billing-service/src/main/java/com/bidcast/billing_service/payment/Payment.java
+++ b/billing-service/src/main/java/com/bidcast/billing_service/payment/Payment.java
@@ -2,6 +2,7 @@ package com.bidcast.billing_service.payment;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.AccessLevel;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -12,17 +13,19 @@ import java.util.UUID;
 @Entity
 @Table(name = "payments")
 @Getter
-@Setter
-@NoArgsConstructor
+@Setter(AccessLevel.PROTECTED) 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class Payment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Setter(AccessLevel.NONE)
     private UUID id;
 
     @Version
+    @Setter(AccessLevel.NONE)
     private Long version;
 
     @Column(nullable = false)
@@ -47,4 +50,32 @@ public class Payment {
 
     @UpdateTimestamp
     private Instant updatedAt;
+
+    /**
+     * Registra la preferencia generada en el gateway de pagos.
+     */
+    public void registerPreference(String mpPreferenceId) {
+        if (this.mpPreferenceId != null) {
+            throw new IllegalStateException("Payment preference already registered");
+        }
+        this.mpPreferenceId = mpPreferenceId;
+    }
+
+    /**
+     * Marca el pago como aprobado tras la validación del webhook.
+     * Devuelve true si el pago acaba de ser aprobado en esta llamada.
+     */
+    public boolean approve(String mpPaymentId) {
+        if (this.status == PaymentStatus.APPROVED) {
+            return false; // Ya estaba aprobado, no hubo cambios.
+        }
+        
+        if (this.status == PaymentStatus.CANCELLED || this.status == PaymentStatus.REJECTED) {
+            throw new IllegalStateException("Cannot approve a payment that is already " + this.status);
+        }
+
+        this.status = PaymentStatus.APPROVED;
+        this.mpPaymentId = mpPaymentId;
+        return true; // Estado actualizado correctamente.
+    }
 }

--- a/billing-service/src/main/java/com/bidcast/billing_service/payment/PaymentPreferenceService.java
+++ b/billing-service/src/main/java/com/bidcast/billing_service/payment/PaymentPreferenceService.java
@@ -40,7 +40,6 @@ public class PaymentPreferenceService {
         log.info("Creating payment preference for advertiser: {}", request.advertiserId());
 
         // 1. Guardamos el registro de pago pendiente en nuestra DB
-        // Nota: save() de JpaRepository ya es transaccional por defecto.
         Payment payment = Payment.builder()
                 .advertiserId(request.advertiserId())
                 .amount(request.amount())
@@ -53,7 +52,7 @@ public class PaymentPreferenceService {
             // 3. Creamos el item (la recarga de saldo)
             List<PreferenceItemRequest> items = new ArrayList<>();
             PreferenceItemRequest item = PreferenceItemRequest.builder()
-                    .id(payment.getId().toString()) // Referencia a nuestra DB
+                    .id(payment.getId().toString()) 
                     .title(request.description() != null ? request.description() : "Bidcast balance top-up")
                     .quantity(1)
                     .unitPrice(request.amount())
@@ -80,7 +79,7 @@ public class PaymentPreferenceService {
             Preference preference = preferenceClient.create(preferenceRequest);
 
             // 7. Actualizamos nuestro registro con el ID de preferencia de MP
-            payment.setMpPreferenceId(preference.getId());
+            payment.registerPreference(preference.getId());
             paymentRepository.save(payment);
 
             log.info("Payment preference created successfully in Mercado Pago: {}", preference.getId());

--- a/billing-service/src/main/java/com/bidcast/billing_service/payment/WebhookService.java
+++ b/billing-service/src/main/java/com/bidcast/billing_service/payment/WebhookService.java
@@ -60,39 +60,33 @@ public class WebhookService {
 
             com.bidcast.billing_service.payment.Payment localPayment = localPaymentOptional.get();
 
-            // 3. IDEMPOTENCIA: Si ya está aprobado, salimos inmediatamente.
-            if (localPayment.getStatus() == PaymentStatus.APPROVED) {
-                log.info("Payment {} was already processed (APPROVED). No action taken.", externalReference);
-                return;
-            }
-
-            // 4. Si el pago está aprobado en MP, actualizamos y disparamos crédito
+            // 3. Si el pago está aprobado en MP, lo procesamos
             if ("approved".equalsIgnoreCase(mpPayment.getStatus())) {
                 log.info("Payment {} verified as APPROVED in Mercado Pago.", paymentId);
                 
-                localPayment.setStatus(PaymentStatus.APPROVED);
-                localPayment.setMpPaymentId(paymentId);
-                
-                // Al persistir, si otro hilo ya lo hizo, @Version lanzará OptimisticLockingFailureException
-                // y Spring hará rollback automático.
-                paymentRepository.save(localPayment);
+                // Usamos el método rico que maneja la idempotencia internamente
+                if (localPayment.approve(paymentId)) {
+                    paymentRepository.save(localPayment);
 
-                // 5. EVENTO DE CRÉDITO (Event-Driven Architecture)
-                WalletCreditEvent event = new WalletCreditEvent(
-                        localPayment.getAdvertiserId(),
-                        localPayment.getAmount(),
-                        paymentId,
-                        localPayment.getId().toString()
-                );
-                
-                rabbitTemplate.convertAndSend(
-                        RabbitMQConfig.EXCHANGE_BILLING,
-                        RabbitMQConfig.ROUTING_KEY_CREDIT,
-                        event
-                );
-                
-                log.info("Credit of {} sent to RabbitMQ for advertiser: {}", 
-                         localPayment.getAmount(), localPayment.getAdvertiserId());
+                    // 4. EVENTO DE CRÉDITO (Event-Driven Architecture)
+                    WalletCreditEvent event = new WalletCreditEvent(
+                            localPayment.getAdvertiserId(),
+                            localPayment.getAmount(),
+                            paymentId,
+                            localPayment.getId().toString()
+                    );
+                    
+                    rabbitTemplate.convertAndSend(
+                            RabbitMQConfig.EXCHANGE_BILLING,
+                            RabbitMQConfig.ROUTING_KEY_CREDIT,
+                            event
+                    );
+                    
+                    log.info("Credit of {} sent to RabbitMQ for advertiser: {}", 
+                             localPayment.getAmount(), localPayment.getAdvertiserId());
+                } else {
+                    log.info("Payment {} was already processed (APPROVED). No action taken.", externalReference);
+                }
 
             } else {
                 log.warn("Payment {} has status {} in Mercado Pago. No balance will be credited.", 

--- a/user-service/src/main/java/com/bidcast/user_service/user/User.java
+++ b/user-service/src/main/java/com/bidcast/user_service/user/User.java
@@ -25,6 +25,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,17 +35,19 @@ import lombok.Setter;
 @Entity
 @Table(name = "users")
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@Setter(AccessLevel.PROTECTED) 
+@NoArgsConstructor(access = AccessLevel.PROTECTED) 
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 @Builder
 public class User implements UserDetails {
     
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @Setter(AccessLevel.NONE)
     private UUID id;
 
     @Column(nullable = false, unique = true)
+    @Setter(AccessLevel.NONE)
     private String email;
     
     @Column(nullable = false)
@@ -61,15 +64,23 @@ public class User implements UserDetails {
     @Enumerated(EnumType.STRING)        
     @Column(name = "role")  
     @Builder.Default            
+    @Setter(AccessLevel.NONE)
     private Set<UserRole> roles = new HashSet<>();
 
     @CreationTimestamp
     @Column(updatable = false) 
+    @Setter(AccessLevel.NONE)
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
+    @Setter(AccessLevel.NONE)
     private LocalDateTime updatedAt;
 
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
 
     @Override
     public String getUsername() {

--- a/user-service/src/test/java/com/bidcast/user_service/auth/AuthServiceTest.java
+++ b/user-service/src/test/java/com/bidcast/user_service/auth/AuthServiceTest.java
@@ -60,7 +60,7 @@ class AuthServiceTest {
                 "secret123",
                 Set.of(UserRole.ADVERTISER)
         );
-        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(new User()));
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(User.builder().build()));
 
         assertThrows(DuplicateResourceException.class, () -> authService.register(request));
         verify(userRepository, never()).save(any(User.class));

--- a/wallet-service/src/main/java/com/bidcast/wallet_service/wallet/Wallet.java
+++ b/wallet-service/src/main/java/com/bidcast/wallet_service/wallet/Wallet.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,8 +32,8 @@ import java.util.UUID;
         @UniqueConstraint(name = "uk_wallet_owner", columnNames = { "owner_id", "owner_type" })
 })
 @Getter
-@Setter
-@NoArgsConstructor
+@Setter(AccessLevel.PROTECTED) 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Schema(name = "Wallet", description = "Current wallet state within the ledger")
@@ -44,11 +45,13 @@ public class Wallet {
     private UUID id;
 
     @Column(name = "owner_id", nullable = false)
+    @Setter(AccessLevel.NONE)
     @Schema(description = "Wallet owner identifier", example = "2b9fd6d4-ef58-4d56-9aa2-8d6f72d5ce59")
     private UUID ownerId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "owner_type", nullable = false, length = 20)
+    @Setter(AccessLevel.NONE)
     @Schema(description = "Wallet owner type", example = "ADVERTISER")
     private WalletOwnerType ownerType;
 
@@ -64,6 +67,7 @@ public class Wallet {
             columnDefinition = "DECIMAL(12,4) CHECK (balance >= 0)"
     )
     @Builder.Default
+    @Setter(AccessLevel.NONE) 
     @Schema(description = "Available balance", example = "1060.0000")
     private BigDecimal balance = BigDecimal.ZERO;
 
@@ -75,6 +79,7 @@ public class Wallet {
             columnDefinition = "DECIMAL(12,4) CHECK (frozen_balance >= 0)"
     )
     @Builder.Default
+    @Setter(AccessLevel.NONE) 
     @Schema(description = "Reserved or frozen balance for pending operations", example = "40.0000")
     private BigDecimal frozenBalance = BigDecimal.ZERO;
 

--- a/wallet-service/src/test/java/com/bidcast/wallet_service/wallet/WalletServiceTest.java
+++ b/wallet-service/src/test/java/com/bidcast/wallet_service/wallet/WalletServiceTest.java
@@ -40,7 +40,7 @@ class WalletServiceTest {
         when(walletRepository.findByOwnerIdAndOwnerType(ownerId, WalletOwnerType.ADVERTISER)).thenReturn(Optional.empty());
         when(walletRepository.save(any(Wallet.class))).thenAnswer(invocation -> {
             Wallet wallet = invocation.getArgument(0);
-            wallet.setId(UUID.randomUUID());
+            org.springframework.test.util.ReflectionTestUtils.setField(wallet, "id", UUID.randomUUID());
             return wallet;
         });
 


### PR DESCRIPTION
## Summary

This PR improves domain responsibility boundaries across all microservices by relocating business rules and state validation from the Service layer into the Domain layer.

Several inconsistencies and invalid state transitions were identified during testing, and this refactor ensures entities enforce their own invariants.

## Key Changes

- Responsibility Fix: Domain entities now own their business rules instead of relying on external service validation.
- Encapsulation: Restricted Lombok @Setter access to PROTECTED to avoid unintended state changes.
- Explicit Domain Actions: Replaced generic setters with intention-revealing methods (e.g., payment.approve(), campaign.activate(), wallet.debit()).
- State Validation: Added safeguards to prevent invalid transitions (e.g., a cancelled payment cannot be approved).
- Service Simplification: Services were adjusted to focus on orchestration and coordination rather than business rule enforcement.
- Test Adjustments: Updated unit/integration tests to follow the new domain constraints using Builders and ReflectionTestUtils when needed.

## Services Affected

- billing-service
- user-service
- auction-service
- advertisement-service
wallet-service